### PR TITLE
Corrigindo TransactionMessage para EventoDeTransacao

### DIFF
--- a/informacao_suporte/kafka-configuration.md
+++ b/informacao_suporte/kafka-configuration.md
@@ -118,8 +118,8 @@ Agora a nossa configuração do consumidor está tudo ok, vamos configurar nosso
 
 ```java
 @Bean
-public ConcurrentKafkaListenerContainerFactory<String, TransactionMessage> kafkaListenerContainerFactory() {
-    ConcurrentKafkaListenerContainerFactory<String, TransactionMessage> factory = new ConcurrentKafkaListenerContainerFactory<>();
+public ConcurrentKafkaListenerContainerFactory<String, EventoDeTransacao> kafkaListenerContainerFactory() {
+    ConcurrentKafkaListenerContainerFactory<String, EventoDeTransacao> factory = new ConcurrentKafkaListenerContainerFactory<>();
     factory.setConsumerFactory(transactionConsumerFactory());
 
     return factory;


### PR DESCRIPTION
- No 7º passo da configuração do kafka usa o EventoDeTransacao. Sugestão para deixar igual por questões de padronização e evitar o erro na hora de compilar